### PR TITLE
Add screens using the gpt3 generated text

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-
-import 'screens/home_screen.dart';
+import 'package:galacticcoders_website/screens/home_screen.dart';
 
 void main() {
   runApp(const GalacticCoders());

--- a/lib/screens/about_us_screen.dart
+++ b/lib/screens/about_us_screen.dart
@@ -1,0 +1,47 @@
+// Copyright 2021 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+class AboutUsScreen extends StatelessWidget {
+  const AboutUsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context)
+        .textTheme
+        .apply(displayColor: Theme.of(context).colorScheme.onSurface);
+    return Expanded(
+      child: ListView(
+        children: <Widget>[
+          const SizedBox(height: 7),
+          TextStyleExample(name: "About Us", style: textTheme.displayMedium!),
+          TextStyleExample(
+              name:
+                  "Galactic Coders is made up of a diverse team of individuals with different backgrounds and expertise. Our members have experience in a variety of programming languages and technologies, and are always eager to learn and grow. We believe in the power of collaboration and community, and strive to create a supportive and inclusive environment for our members.",
+              style: textTheme.bodyMedium!),
+        ],
+      ),
+    );
+  }
+}
+
+class TextStyleExample extends StatelessWidget {
+  const TextStyleExample({
+    super.key,
+    required this.name,
+    required this.style,
+  });
+
+  final String name;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Text(name, style: style),
+    );
+  }
+}

--- a/lib/screens/blog_screen.dart
+++ b/lib/screens/blog_screen.dart
@@ -1,0 +1,56 @@
+// Copyright 2021 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+class BlogScreen extends StatelessWidget {
+  const BlogScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context)
+        .textTheme
+        .apply(displayColor: Theme.of(context).colorScheme.onSurface);
+    return Expanded(
+      child: ListView(
+        children: <Widget>[
+          const SizedBox(height: 7),
+          TextStyleExample(name: "Blog", style: textTheme.displayMedium!),
+          TextStyleExample(
+              name:
+                  "Galactic Coders is always looking for ways to share our knowledge and expertise with the wider community. Our blog features articles and posts written by our members and guest contributors, covering a range of topics related to coding and software development. Some of the recent posts on our blog include: ",
+              style: textTheme.bodyMedium!),
+          TextStyleExample(
+              name: "\"Top 10 coding languages to learn in 2021\"",
+              style: textTheme.titleMedium!),
+          TextStyleExample(
+              name: "\"How to get started with machine learning\"",
+              style: textTheme.titleMedium!),
+          TextStyleExample(
+              name: "\"5 essential tools for every software developer\"",
+              style: textTheme.titleMedium!),
+        ],
+      ),
+    );
+  }
+}
+
+class TextStyleExample extends StatelessWidget {
+  const TextStyleExample({
+    super.key,
+    required this.name,
+    required this.style,
+  });
+
+  final String name;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Text(name, style: style),
+    );
+  }
+}

--- a/lib/screens/component_screen.dart
+++ b/lib/screens/component_screen.dart
@@ -1,0 +1,152 @@
+// Copyright 2021 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+const List<NavigationDestination> appBarDestinations = [
+  NavigationDestination(
+    tooltip: "",
+    icon: Icon(Icons.home_outlined),
+    label: 'About Us',
+    selectedIcon: Icon(Icons.home),
+  ),
+  NavigationDestination(
+    tooltip: "",
+    icon: Icon(Icons.star_border_outlined),
+    label: 'Projects',
+    selectedIcon: Icon(Icons.star),
+  ),
+  NavigationDestination(
+    tooltip: "",
+    icon: Icon(Icons.event_outlined),
+    label: 'Events',
+    selectedIcon: Icon(Icons.event),
+  ),
+  NavigationDestination(
+    tooltip: "",
+    icon: Icon(Icons.rss_feed_outlined),
+    label: 'Blog',
+    selectedIcon: Icon(Icons.rss_feed),
+  ),
+  NavigationDestination(
+    tooltip: "",
+    icon: Icon(Icons.contact_page_outlined),
+    label: 'Contact us',
+    selectedIcon: Icon(Icons.contact_page),
+  ),
+];
+
+final List<NavigationRailDestination> navRailDestinations = appBarDestinations
+    .map(
+      (destination) => NavigationRailDestination(
+        icon: Tooltip(
+          message: destination.label,
+          child: destination.icon,
+        ),
+        selectedIcon: Tooltip(
+          message: destination.label,
+          child: destination.selectedIcon,
+        ),
+        label: Text(destination.label),
+      ),
+    )
+    .toList();
+
+const List<Widget> exampleBarDestinations = [
+  NavigationDestination(
+    tooltip: "",
+    icon: Icon(Icons.explore_outlined),
+    label: 'Explore',
+    selectedIcon: Icon(Icons.explore),
+  ),
+  NavigationDestination(
+    tooltip: "",
+    icon: Icon(Icons.pets_outlined),
+    label: 'Pets',
+    selectedIcon: Icon(Icons.pets),
+  ),
+  NavigationDestination(
+    tooltip: "",
+    icon: Icon(Icons.account_box_outlined),
+    label: 'Account',
+    selectedIcon: Icon(Icons.account_box),
+  )
+];
+
+class NavigationBars extends StatefulWidget {
+  final void Function(int)? onSelectItem;
+  final int selectedIndex;
+  final bool isExampleBar;
+
+  const NavigationBars(
+      {super.key,
+      this.onSelectItem,
+      required this.selectedIndex,
+      required this.isExampleBar});
+
+  @override
+  State<NavigationBars> createState() => _NavigationBarsState();
+}
+
+class _NavigationBarsState extends State<NavigationBars> {
+  int _selectedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedIndex = widget.selectedIndex;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NavigationBar(
+      selectedIndex: _selectedIndex,
+      onDestinationSelected: (index) {
+        setState(() {
+          _selectedIndex = index;
+        });
+        if (!widget.isExampleBar) widget.onSelectItem!(index);
+      },
+      destinations:
+          widget.isExampleBar ? exampleBarDestinations : appBarDestinations,
+    );
+  }
+}
+
+class NavigationRailSection extends StatefulWidget {
+  final void Function(int) onSelectItem;
+  final int selectedIndex;
+
+  const NavigationRailSection(
+      {super.key, required this.onSelectItem, required this.selectedIndex});
+
+  @override
+  State<NavigationRailSection> createState() => _NavigationRailSectionState();
+}
+
+class _NavigationRailSectionState extends State<NavigationRailSection> {
+  int _selectedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedIndex = widget.selectedIndex;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NavigationRail(
+      minWidth: 50,
+      destinations: navRailDestinations,
+      selectedIndex: _selectedIndex,
+      useIndicator: true,
+      onDestinationSelected: (index) {
+        setState(() {
+          _selectedIndex = index;
+        });
+        widget.onSelectItem(index);
+      },
+    );
+  }
+}

--- a/lib/screens/contact_us_screen.dart
+++ b/lib/screens/contact_us_screen.dart
@@ -1,0 +1,47 @@
+// Copyright 2021 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+class ContactUsScreen extends StatelessWidget {
+  const ContactUsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context)
+        .textTheme
+        .apply(displayColor: Theme.of(context).colorScheme.onSurface);
+    return Expanded(
+      child: ListView(
+        children: <Widget>[
+          const SizedBox(height: 7),
+          TextStyleExample(name: "Contact Us", style: textTheme.displayMedium!),
+          TextStyleExample(
+              name:
+                  "Want to get in touch with Galactic Coders? We would love to hear from you! You can contact us through our website's contact form, or email us at [email protected] You can also follow us on social media to stay up-to-date with our latest projects and events. If you are interested in joining our group or collaborating with us on a project, please don't hesitate to reach out! ",
+              style: textTheme.bodyMedium!),
+        ],
+      ),
+    );
+  }
+}
+
+class TextStyleExample extends StatelessWidget {
+  const TextStyleExample({
+    super.key,
+    required this.name,
+    required this.style,
+  });
+
+  final String name;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Text(name, style: style),
+    );
+  }
+}

--- a/lib/screens/events_screen.dart
+++ b/lib/screens/events_screen.dart
@@ -1,0 +1,64 @@
+// Copyright 2021 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+class EventsScreen extends StatelessWidget {
+  const EventsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context)
+        .textTheme
+        .apply(displayColor: Theme.of(context).colorScheme.onSurface);
+    return Expanded(
+      child: ListView(
+        children: <Widget>[
+          const SizedBox(height: 7),
+          TextStyleExample(name: "Events", style: textTheme.displayMedium!),
+          TextStyleExample(
+              name:
+                  "Galactic Coders is actively involved in the coding and software development community, and we regularly organize and participate in events such as hackathons, workshops, and meetups. Some of the events that we have been involved in include: ",
+              style: textTheme.bodyMedium!),
+          TextStyleExample(name: "Code-A-Thon:", style: textTheme.titleMedium!),
+          TextStyleExample(
+              name:
+                  "A 24-hour hackathon where teams of coders compete to build the best software projects ",
+              style: textTheme.bodyMedium!),
+          TextStyleExample(
+              name: "Coding Bootcamp:", style: textTheme.titleMedium!),
+          TextStyleExample(
+              name:
+                  "A week-long intensive workshop that teaches participants the fundamentals of coding and software development ",
+              style: textTheme.bodyMedium!),
+          TextStyleExample(
+              name: "Meet and Code:", style: textTheme.titleMedium!),
+          TextStyleExample(
+              name:
+                  "A monthly meetup where members can network and share ideas with other coders and tech enthusiasts ",
+              style: textTheme.bodyMedium!),
+        ],
+      ),
+    );
+  }
+}
+
+class TextStyleExample extends StatelessWidget {
+  const TextStyleExample({
+    super.key,
+    required this.name,
+    required this.style,
+  });
+
+  final String name;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Text(name, style: style),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,39 +1,195 @@
-import 'package:flutter/material.dart';
+// Copyright 2021 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-class HomeScreen extends StatelessWidget {
+import 'package:flutter/material.dart';
+import 'package:galacticcoders_website/screens/about_us_screen.dart';
+import 'package:galacticcoders_website/screens/blog_screen.dart';
+import 'package:galacticcoders_website/screens/component_screen.dart';
+import 'package:galacticcoders_website/screens/contact_us_screen.dart';
+import 'package:galacticcoders_website/screens/projects_screen.dart';
+import 'package:galacticcoders_website/screens/events_screen.dart';
+
+void main() {
+  runApp(const HomeScreen());
+}
+
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('GalacticCoders')),
-      body: Container(
-        decoration: const BoxDecoration(
-            image: DecorationImage(
-          image: AssetImage('assets/spiral-galaxy-synthwave.png'),
-          fit: BoxFit.cover,
-        )),
-        child: Center(
-          child: Container(
-            padding: const EdgeInsets.all(24),
-            decoration: const BoxDecoration(
-              borderRadius: BorderRadius.all(Radius.circular(20)),
-              color: Colors.white70,
-            ),
-            child: const Text(
-              'Hello! We are Galactic Coders, a small but mighty group of individuals who share a passion for coding, collaboration, and learning. As a team, we enjoy working on various software development projects and ideas, organizing and participating in hackathons, and playing board games together. We are always looking to expand our knowledge and share it with others, and we are excited to see what the future holds for our group.',
-              textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 22, shadows: [
-                Shadow(
-                  offset: Offset(1.0, 1.0),
-                  blurRadius: 2.0,
-                  color: Colors.grey,
-                )
-              ]),
-            ),
-          ),
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+// NavigationRail shows if the screen width is greater or equal to
+// screenWidthThreshold; otherwise, NavigationBar is used for navigation.
+const double narrowScreenWidthThreshold = 450;
+
+const Color m3BaseColor = Color(0xff6750a4);
+const List<Color> colorOptions = [
+  m3BaseColor,
+  Colors.blue,
+  Colors.teal,
+  Colors.green,
+  Colors.yellow,
+  Colors.orange,
+  Colors.pink
+];
+const List<String> colorText = <String>[
+  "M3 Baseline",
+  "Blue",
+  "Teal",
+  "Green",
+  "Yellow",
+  "Orange",
+  "Pink",
+];
+
+class _HomeScreenState extends State<HomeScreen> {
+  bool useLightMode = true;
+  int screenIndex = 0;
+
+  late ThemeData themeData;
+
+  @override
+  initState() {
+    super.initState();
+    themeData = updateThemes(useLightMode);
+  }
+
+  ThemeData updateThemes(bool useLightMode) {
+    return ThemeData(
+        colorSchemeSeed: Colors.blue,
+        useMaterial3: true,
+        brightness: useLightMode ? Brightness.light : Brightness.dark);
+  }
+
+  void handleScreenChanged(int selectedScreen) {
+    setState(() {
+      screenIndex = selectedScreen;
+    });
+  }
+
+  void handleBrightnessChange() {
+    setState(() {
+      useLightMode = !useLightMode;
+      themeData = updateThemes(useLightMode);
+    });
+  }
+
+  void handleMaterialVersionChange() {
+    setState(() {
+      themeData = updateThemes(useLightMode);
+    });
+  }
+
+  void handleColorSelect(int value) {
+    setState(() {
+      themeData = updateThemes(useLightMode);
+    });
+  }
+
+  Widget createScreenFor(int screenIndex, bool showNavBarExample) {
+    switch (screenIndex) {
+      case 0:
+        return const AboutUsScreen();
+      case 1:
+        return const ProjectsScreen();
+      case 2:
+        return const EventsScreen();
+      case 3:
+        return const BlogScreen();
+      case 4:
+        return const ContactUsScreen();
+      default:
+        return const AboutUsScreen();
+    }
+  }
+
+  PreferredSizeWidget createAppBar() {
+    return AppBar(
+      title: const Text("Galactic Coders"),
+      actions: [
+        IconButton(
+          icon: useLightMode
+              ? const Icon(Icons.wb_sunny_outlined)
+              : const Icon(Icons.wb_sunny),
+          onPressed: handleBrightnessChange,
+          tooltip: "Toggle brightness",
         ),
-      ),
+        PopupMenuButton(
+          icon: const Icon(Icons.more_vert),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+          itemBuilder: (context) {
+            return List.generate(colorOptions.length, (index) {
+              return PopupMenuItem(
+                  value: index,
+                  child: Wrap(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(left: 10),
+                        child: Icon(
+                          index == true
+                              ? Icons.color_lens
+                              : Icons.color_lens_outlined,
+                          color: colorOptions[index],
+                        ),
+                      ),
+                      Padding(
+                          padding: const EdgeInsets.only(left: 20),
+                          child: Text(colorText[index]))
+                    ],
+                  ));
+            });
+          },
+          onSelected: handleColorSelect,
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: 'Material 3',
+      themeMode: useLightMode ? ThemeMode.light : ThemeMode.dark,
+      theme: themeData,
+      home: LayoutBuilder(builder: (context, constraints) {
+        if (constraints.maxWidth < narrowScreenWidthThreshold) {
+          return Scaffold(
+            appBar: createAppBar(),
+            body: Row(children: <Widget>[
+              createScreenFor(screenIndex, false),
+            ]),
+            bottomNavigationBar: NavigationBars(
+              onSelectItem: handleScreenChanged,
+              selectedIndex: screenIndex,
+              isExampleBar: false,
+            ),
+          );
+        } else {
+          return Scaffold(
+            appBar: createAppBar(),
+            body: SafeArea(
+              bottom: false,
+              top: false,
+              child: Row(
+                children: <Widget>[
+                  Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 5),
+                      child: NavigationRailSection(
+                          onSelectItem: handleScreenChanged,
+                          selectedIndex: screenIndex)),
+                  const VerticalDivider(thickness: 1, width: 1),
+                  createScreenFor(screenIndex, true),
+                ],
+              ),
+            ),
+          );
+        }
+      }),
     );
   }
 }

--- a/lib/screens/projects_screen.dart
+++ b/lib/screens/projects_screen.dart
@@ -1,0 +1,61 @@
+// Copyright 2021 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+class ProjectsScreen extends StatelessWidget {
+  const ProjectsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context)
+        .textTheme
+        .apply(displayColor: Theme.of(context).colorScheme.onSurface);
+    return Expanded(
+      child: ListView(
+        children: <Widget>[
+          const SizedBox(height: 7),
+          TextStyleExample(name: "Projects", style: textTheme.displayMedium!),
+          TextStyleExample(
+              name: "Space Explorer:", style: textTheme.titleMedium!),
+          TextStyleExample(
+              name:
+                  "A mobile app that allows users to explore the solar system and learn about different planets and their features",
+              style: textTheme.bodyMedium!),
+          TextStyleExample(
+              name: "Galactic Chat:", style: textTheme.titleMedium!),
+          TextStyleExample(
+              name:
+                  "A web-based chat platform that allows users to communicate with each other in real-time",
+              style: textTheme.bodyMedium!),
+          TextStyleExample(
+              name: "Star Tracker:", style: textTheme.titleMedium!),
+          TextStyleExample(
+              name:
+                  "A desktop application that helps users track and monitor their favorite celestial bodies",
+              style: textTheme.bodyMedium!),
+        ],
+      ),
+    );
+  }
+}
+
+class TextStyleExample extends StatelessWidget {
+  const TextStyleExample({
+    super.key,
+    required this.name,
+    required this.style,
+  });
+
+  final String name;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Text(name, style: style),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,7 +5,6 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:galacticcoders_website/main.dart';


### PR DESCRIPTION
This pull request includes significant updates to the `GalacticCoders` Flutter application, adding new screens and improving the navigation structure. The most important changes include the addition of new screens, updates to the main screen to support navigation, and the introduction of a navigation bar and navigation rail.

### New Screens Added:

* [`lib/screens/about_us_screen.dart`](diffhunk://#diff-46704f32eecc0547f9d7eaac134c5f82270787c7be074d04b6aeb7a5ce852358R1-R47): Added a new `AboutUsScreen` with information about the Galactic Coders team.
* [`lib/screens/blog_screen.dart`](diffhunk://#diff-bebc45cbe4956d2f0c660e9d5828b87e6c873c6b7a3b5cb78cd19b6fa240af23R1-R56): Added a new `BlogScreen` showcasing blog posts.
* [`lib/screens/contact_us_screen.dart`](diffhunk://#diff-2ae9b204841ed3be438a5598f63e324ed839b33663a24e3da816d33455ba2dbbR1-R47): Added a new `ContactUsScreen` with contact information.
* [`lib/screens/events_screen.dart`](diffhunk://#diff-0b5c24ab70e77c8d15b493bacc9693ba90fcb4feb02221fdd9346a2dfc78fd3dR1-R64): Added a new `EventsScreen` detailing events organized by the team.
* [`lib/screens/projects_screen.dart`](diffhunk://#diff-961ee6e7131fe691b71a8416f6cc75a620bb365159a29415738cd267e1516959R1-R61): Added a new `ProjectsScreen` highlighting various projects.

### Navigation Enhancements:

* [`lib/screens/component_screen.dart`](diffhunk://#diff-00e3ee956055c1c56d3a0575b74aad57939d9a82a3eaa5d0d6b5252a35de4224R1-R152): Introduced `NavigationBars` and `NavigationRailSection` widgets to handle navigation between different screens.
* [`lib/screens/home_screen.dart`](diffhunk://#diff-935e56a557f0ab902a679f47de66345d9f47058bccb96f870e6383d19e2c86ddR1-R192): Updated `HomeScreen` to a stateful widget, added navigation logic, and included new screens in the navigation structure.

### Other Changes:

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L2-R2): Updated import path for `home_screen.dart` to reflect the new package structure.
* [`test/widget_test.dart`](diffhunk://#diff-f6381878cca7fc4e1afad2698839797982d6b77ed29020059456a5ae65ee75acL8): Removed an unused import statement.